### PR TITLE
!fix: base64 decoded contents / no interaction key check ffi 0.4.6+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TEST?=./...
 .DEFAULT_GOAL := ci
-FFI_VERSION=0.3.15
-VERSION=0.0.7
+FFI_VERSION=0.4.13
+VERSION=0.1.0
 PROJECT=matt
 
 ci:: deps clean bin test

--- a/pact-plugin.json
+++ b/pact-plugin.json
@@ -1,7 +1,7 @@
 {
   "pluginInterfaceVersion": 1,
   "name": "matt",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "executableType": "exec",
   "minimumRequiredVersion": null,
   "entryPoint": "matt",


### PR DESCRIPTION
See https://github.com/pact-foundation/pact-reference/issues/366#issuecomment-1910686240 for content

Evident in ci runs updating FFI 0.4.6+ against pact-go and pact-js plugin example tests which use this plugin